### PR TITLE
docs: Fix typo in src/README.md

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 
 Orbs are shipped as individual `orb.yml` files, however, to make development easier, it is possible to author an orb in _unpacked_ form, which can be _packed_ with the CircleCI CLI and published.
 
-The default `.circleci/config.yml` file contains the configuration code needed to automatically pack, test, and deploy and changes made to the contents of the orb source in this directory.
+The default `.circleci/config.yml` file contains the configuration code needed to automatically pack, test, and deploy any changes made to the contents of the orb source in this directory.
 
 ## @orb.yml
 


### PR DESCRIPTION
The PR fixes a small typo and adds a newline (an artefact of using GH editor) at the file end