### PR TITLE
fix: remove all shellcheck exclusions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ workflows:
       - orb-tools/review:
           filters: *filters
       - shellcheck/check:
-          exclude: SC2148,SC2038,SC2086,SC2002,SC2016
           filters: *filters
       - orb-tools/publish:
           orb-name: <namespace>/<orb-name>


### PR DESCRIPTION
This PR removes the following exclusions from the template:

[SC2148](https://www.shellcheck.net/wiki/SC2148): Tips depend on target shell and yours is unknown. Add a shebang.

[SC2038](https://www.shellcheck.net/wiki/SC2038): Use `-print0`/`-0` or `find -exec +` to allow for non-alphanumeric filenames.

[SC2086](https://www.shellcheck.net/wiki/SC2086): Double quote to prevent globbing and word splitting.

[SC2002](https://www.shellcheck.net/wiki/SC2002): Useless cat. Consider `cmd < file | ..` or `cmd file | ..` instead.

[SC2016](https://www.shellcheck.net/wiki/SC2016): Expressions don't expand in single quotes, use double quotes for that. 

Having these checks as part of the review process will increase the orb quality and force the end user to exclude them consciously.