### PR TITLE
chore: use latest orb-tools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.3
+  orb-tools: circleci/orb-tools@11.4
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   <orb-name>: <namespace>/<orb-name>@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.3
+  orb-tools: circleci/orb-tools@11.4
 
 filters: &filters
   tags:


### PR DESCRIPTION
This PR updates the template to use the latest published Orb Tools v11.4.

Note after merging, the repo would require a version tag update for the CircleCI CLI init command to pick up the changes when users use the CLI.  (Ref #8 ).