### PR TITLE
fix: remove `publish` from the `config.yml`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,18 +19,10 @@ workflows:
           filters: *filters
       - shellcheck/check:
           filters: *filters
-      - orb-tools/publish:
-          orb_name: <namespace>/<orb-name>
-          vcs_type: << pipeline.project.type >>
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          # Use a context to hold your publishing token.
-          context: <publishing-context>
-          filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
           orb_name: <orb-name>
-          requires: [orb-tools/publish]
+          requires: [orb-tools/lint, orb-tools/pack, orb-tools/review, shellcheck/check]
           filters: *filters


### PR DESCRIPTION
## Changes

- Remove the `publish` step from the `config.yml` as it is no longer necessary with Orb Tools 12.