### PR TITLE
Add Developmnent orb Information To README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,26 @@ We welcome [issues](https://github.com/<organization>/<project-name>/issues) to 
 5. Now ensure the version tag selected is semantically accurate based on the changes included.
 6. Click _"Publish Release"_.
     - This will push a new tag and trigger your publishing pipeline on CircleCI.
+
+### Development Orbs
+
+Prerequisites:
+
+- An initial sevmer deployment must be performed in order for Development orbs to be published and seen in the [Orb Registry](https://circleci.com/developer/orbs).
+
+A [Development orb](https://circleci.com/docs/orb-concepts/#development-orbs) can be created to help with rapid development or testing. To create a Development orb, change the `orb-tools/publish` job in `test-deploy.yml` to be the following:
+
+```yaml
+- orb-tools/publish:
+    orb_name: <namespace>/<orb-name>
+    vcs_type: << pipeline.project.type >>
+    pub_type: dev
+    # Ensure this job requires all test jobs and the pack job.
+    requires:
+      - orb-tools/pack
+      - command-test
+    context: <publishing-context>
+    filters: *filters
+```
+
+The job output will contain a link to the Development orb Registry page. The parameters `enable_pr_comment` and `github_token` can be set to add the relevant publishing information onto a pull request. Please refer to the [orb-tools/publish](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish) documentation for more information and options.


### PR DESCRIPTION
Due to an issue with the output of `circleci orb publish` users attempting to publish a Development orb can reach a state where the `orb-tools/publish` job is successful when using `pub_type: dev` but the orb is not actually published and the link to the Orb Registry leads to a 404.

Added information about publishing Development orbs, including a prerequisite which will prevent the above situation.